### PR TITLE
Add back button to GrievancesRegistrationForm

### DIFF
--- a/user/src/components/GrievancesRegistrationForm.jsx
+++ b/user/src/components/GrievancesRegistrationForm.jsx
@@ -96,6 +96,14 @@ const GrievancesRegistrationForm = ({ isAuthenticated }) => {
   return (
     <div className="bg-orange-50/30 dark:bg-gray-900/30 py-12 transition-colors duration-300">
         <Toaster position="top-center" richColors />
+        <button
+          type="button"
+          onClick={() => window.history.back()} // or use router navigation
+          className="items-center px-4 border border-orange-600 dark:border-orange-400 
+               text-orange-600 dark:text-orange-400 rounded-lg font-semibold
+               hover:bg-orange-600 hover:text-white dark:hover:bg-orange-400 dark:hover:text-gray-900 
+               transition-colors duration-200 ml-8 mb-2 py-2"
+        >Back</button>
         <form className="p-4 sm:p-8 space-y-8 max-w-6xl mx-auto bg-white dark:bg-gray-800 rounded-2xl shadow-2xl transition-colors duration-300" onSubmit={handleSubmit(onSubmit)}>
             <h1 className="text-4xl font-extrabold text-center text-orange-900 dark:text-orange-400 jost">Grievance Registration Form</h1>
             


### PR DESCRIPTION
This PR resolves issue #103

- Added a Go Back arrow button at the top-left corner of the Grievance Registration Form.
- The button navigates back to the main Grievances page / previous view.
- Styled the button with border, hover effects, and theme colors.
- Ensured responsiveness for both mobile and desktop screens.

This is how it looks like now:
<img width="1308" height="472" alt="Screenshot 2025-09-24 103638" src="https://github.com/user-attachments/assets/1562a62d-7293-4a81-8e99-5212b6c17149" />

We can also use "Register Now" button style on Grievance page:
<img width="595" height="523" alt="image" src="https://github.com/user-attachments/assets/81facb53-fa9a-4538-9e8a-6fa0d7f6b5f7" />


✨ **Note:** 

- This is my first PR, excited to contribute! Looking forward to your feedback.
- I was initially assigned by @eccentriccoder01 before @krishagandhi0711. Being new to open source, I accidentally unassigned myself. Please guide me and kindly reconsider my changes.
