### PR TITLE
Fix: clear contact form fields after successful submission

### DIFF
--- a/user/src/components/Contact.jsx
+++ b/user/src/components/Contact.jsx
@@ -28,24 +28,33 @@ const Contact = () => {
     setFormData({ ...formData, [e.target.name]: e.target.value });
   };
 
-  const handleSubmit = async (e) => {
-    e.preventDefault();
-    try {
-      const res = await fetch(
-        `${import.meta.env.VITE_API_BASE_URL}/api/v1/contact`,
-        {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify(formData),
-        }
-      );
-      const data = await res.json();
-      alert(data.message); 
-    } catch (err) {
-      console.error(err);
-      alert("Something went wrong. Please try again.");
-    }
-  };
+ const handleSubmit = async (e) => {
+  e.preventDefault();
+  try {
+    const res = await fetch(
+      `${import.meta.env.VITE_API_BASE_URL}/api/v1/contact`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(formData),
+      }
+    );
+    const data = await res.json();
+    alert(data.message);
+
+    // ✅ Reset form fields after success
+    setFormData({
+      name: "",
+      email: "",
+      subject: "",
+      message: "",
+    });
+
+  } catch (err) {
+    console.error(err);
+    alert("Something went wrong. Please try again.");
+  }
+};
 
   return (
     <div className="bg-orange-50/30 dark:bg-gray-900/50 transition-colors duration-300">


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #76 

## Rationale for this change

The Contact Us form retained input values even after a successful message submission. This was causing a poor user experience because users had to manually clear the form to send another message. This change resets the form fields automatically upon successful submission.

## What changes are included in this PR?

- Added `setFormData({...})` in `handleSubmit` to reset all fields (`name`, `email`, `subject`, `message`) after the API call succeeds.
- Ensured existing validation and form functionality remain intact.

## Are these changes tested?

Yes. Tested manually by:
1. Filling in the Contact Us form.
2. Submitting the form.
3. Confirming that an alert is shown and all input fields are cleared.

https://github.com/user-attachments/assets/afb40d32-4fba-4914-b9b5-15c48a176d20

## Are there any user-facing changes?

Yes. After submitting the form, the input fields will now automatically clear, improving the user experience for multiple submissions.
