### PR TITLE
Removed the unnecessary toggle dark-light mode button

### DIFF
--- a/user/src/components/PrivacyPolicy.jsx
+++ b/user/src/components/PrivacyPolicy.jsx
@@ -249,7 +249,7 @@ const sections = [
 
       <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
         {/* Theme Toggle Button */}
-        <div className="flex justify-end mb-6">
+        {/* <div className="flex justify-end mb-6">
           <button
   onClick={() => setDarkMode(!darkMode)}
   data-tooltip-id="themeToggleTip"
@@ -258,10 +258,10 @@ const sections = [
 >
   {darkMode ? <Sun size={20} /> : <Moon size={20} />}
 </button>
-{/* Tooltips */}
+Tooltips
 <Tooltip id="themeToggleTip" style={tooltipStyle} />
 
-        </div>
+        </div> */}
 
         {/* Introduction */}
         <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-lg p-8 mb-8 transition-colors duration-500">


### PR DESCRIPTION
I removed the unnecessary toggle dark - light mode button from the Privacy and Policy page .

Now it is looking like this -

<img width="1912" height="1016" alt="Screenshot 2025-09-29 235815" src="https://github.com/user-attachments/assets/c17b1107-5c3f-46b9-8c58-05413acd1cd5" />

Hi @eccentriccoder01 please check and merge this PR with labels .

Thanks!