### PR TITLE
💡 UX Enhancement: Add Close Button for QR Popup #158

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -18,6 +18,8 @@
         "express": "^4.21.2",
         "firebase": "^10.14.0",
         "google-auth-library": "^10.3.0",
+        "helmet": "^8.1.0",
+        "hpp": "^0.2.3",
         "jsonwebtoken": "^9.0.2",
         "mongoose": "^8.6.3",
         "multer": "^1.4.5-lts.1",
@@ -1994,6 +1996,28 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/helmet": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.1.0.tgz",
+      "integrity": "sha512-jOiHyAZsmnr8LqoPGmCjYAaiuWwjAPLgY8ZX2XrmHawt99/u1y6RgrZMTeoPfpUbV96HOalYgz1qzkRbw54Pmg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/hpp": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/hpp/-/hpp-0.2.3.tgz",
+      "integrity": "sha512-4zDZypjQcxK/8pfFNR7jaON7zEUpXZxz4viyFmqjb3kWNWAHsLEUmWXcdn25c5l76ISvnD6hbOGO97cXUI3Ryw==",
+      "license": "ISC",
+      "dependencies": {
+        "lodash": "^4.17.12",
+        "type-is": "^1.6.12"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/http-errors": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -21,6 +21,8 @@
     "express": "^4.21.2",
     "firebase": "^10.14.0",
     "google-auth-library": "^10.3.0",
+    "helmet": "^8.1.0",
+    "hpp": "^0.2.3",
     "jsonwebtoken": "^9.0.2",
     "mongoose": "^8.6.3",
     "multer": "^1.4.5-lts.1",

--- a/user/src/components/pages/Footer.jsx
+++ b/user/src/components/pages/Footer.jsx
@@ -45,16 +45,47 @@ const Footer = () => {
 
             <div className="flex flex-col sm:flex-row items-center justify-center md:justify-start gap-4">
 
-              {/* QR Code */}
-              <img
-                src={qrcode}
-                alt="QR Code for Mobile App"
-                className={`object-cover rounded-lg border-2 border-amber-500 p-1 cursor-pointer transition-all duration-300 ${isQRActive ? "fixed top-1/2 left-1/2 w-80 h-80 z-50 -translate-x-1/2 -translate-y-1/2 shadow-2xl bg-white" : "w-28 h-28"}`}
-                onClick={toggleQR}
-                data-tooltip-id="qr-tooltip"
-                data-tooltip-content="Scan this QR code to download the SaralSeva app"
-              />
-              <Tooltip id="qr-tooltip" place="top" style={tooltipStyle} />
+            {/* QR Code */}
+{isQRActive && (
+  <div
+    className="fixed inset-0 bg-black bg-opacity-50 z-40 flex items-center justify-center"
+    onClick={toggleQR} // Clicking overlay closes it
+  >
+    <div
+      className="relative"
+      onClick={(e) => e.stopPropagation()} // Prevent closing when clicking QR itself
+    >
+      {/* Close Button */}
+      <button
+        onClick={toggleQR}
+        className="absolute -top-4 -right-4 bg-white rounded-full shadow-md text-black font-bold px-2"
+      >
+        ×
+      </button>
+
+      {/* QR Image */}
+      <img
+        src={qrcode}
+        alt="QR Code for Mobile App"
+        className="w-80 h-80 object-cover rounded-lg border-2 border-amber-500 p-1 shadow-2xl bg-white"
+      />
+    </div>
+  </div>
+)}
+
+{/* Small QR (default view) */}
+{!isQRActive && (
+  <img
+    src={qrcode}
+    alt="QR Code for Mobile App"
+    className="w-28 h-28 object-cover rounded-lg border-2 border-amber-500 p-1 cursor-pointer transition-all duration-300"
+    onClick={toggleQR}
+    data-tooltip-id="qr-tooltip"
+    data-tooltip-content="Scan this QR code to download the SaralSeva app"
+  />
+)}
+
+<Tooltip id="qr-tooltip" place="top" style={tooltipStyle} />
 
               {/* App Store / Play Store Links */}
               <div className="flex flex-col gap-2">


### PR DESCRIPTION
### Description
This PR adds a visible "×" close button to the QR popup for downloading the app.  
Previously, the only way to close was to click the QR itself, which was not obvious.

### Changes
- Added "×" close button aligned to the top-right of the popup
- Enabled closing popup by clicking outside overlay

### Related Issue
Fixes #158